### PR TITLE
Update resource links for brief, code, and data

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ HERO (Swap hero.jpg, title, strapline, and the three links)
 
 **One sentence on impact:** In three days we are prototyping a decision-support toolkit that helps land stewards spot when management practices are failing to prevent ecological thresholds.
 
-**[Sprint brief](updates.md) · [View shared code](https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/tree/main/code) · [Data & access](data.md)**
+**[Sprint brief](assets/Seven%20ways%20to%20measure%20fire%20polygon%20velocity-4.pdf) · [View shared code](https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/blob/main/code/single_hull_demo.py) · [Explore data](https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/blob/main/code/prism_quicklook.py)**
 
 > **About this site:** This public log captures our rapid work at the Innovation Summit. Update it directly in your browser (open a file → pencil icon → Commit changes) so teammates and partners can follow along.
 
@@ -144,13 +144,13 @@ Keeping working lands intact depends on catching tipping points early. Reliable,
 <table>
 <tr>
 <td align="center" width="33%">
-  <a href="updates.md"><img src="assets/button_brief.gif" alt="Read sprint updates" width="240"><br><strong>Read the updates</strong></a>
+  <a href="assets/Seven%20ways%20to%20measure%20fire%20polygon%20velocity-4.pdf"><img src="assets/button_brief.gif" alt="Read the sprint brief" width="240"><br><strong>Read the brief</strong></a>
 </td>
 <td align="center" width="33%">
-  <a href="https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/blob/main/code/prism_quicklook.py"><img src="assets/button_code.gif" alt="View shared code" width="240"><br><strong>View code</strong></a>
+  <a href="https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/blob/main/code/single_hull_demo.py"><img src="assets/button_code.gif" alt="View shared code" width="240"><br><strong>View code</strong></a>
 </td>
 <td align="center" width="33%">
-  <a href="https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/blob/main/code/fired_time_hull_panel.ipynb"><img src="assets/button_data.gif" alt="Explore data workflow" width="240"><br><strong>Explore notebooks</strong></a>
+  <a href="https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/blob/main/code/prism_quicklook.py"><img src="assets/button_data.gif" alt="Explore data workflow" width="240"><br><strong>Explore data</strong></a>
 </td>
 </tr>
 </table>

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -3,7 +3,7 @@
 Quick links the team uses while building the threshold prevention dashboard.
 
 ## Data & storage
-- **CyVerse community folder:** [`Group_17`](https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_17) — upload shared datasets, figures, and deliverables.
+- **CyVerse community folder:** [`Group_17`](https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_17?type=folder&resourceId=25105262-95a2-11f0-b0fb-90e2ba675364) — upload shared datasets, figures, and deliverables.
 - **Earth Engine asset folder:** `users/group17/thresholds_dashboard` — staging area for Landsat and NDVI composites.
 
 ## Collaboration spaces

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,7 +30,7 @@ nav:
   - Storage:
       - Your code: https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/tree/main/code
       - Your documentation: https://github.com/CU-ESIIL/management-practices-prevent-thresholds-innovation-summit-2025__17/tree/main/documentation
-      - Your persistent storage: "https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_17"
+      - Your persistent storage: "https://de.cyverse.org/data/ds/iplant/home/shared/esiil/Innovation_summit/Group_17?type=folder&resourceId=25105262-95a2-11f0-b0fb-90e2ba675364"
   - Orientation:
       - Summit slides: orientation/slides.md
       - ESIIL training: orientation/esiil_training.md


### PR DESCRIPTION
## Summary
- point the brief links to the uploaded PDF and retarget the code and data shortcuts to their requested files
- refresh the featured buttons so their destinations mirror the top-of-page links and label the brief button appropriately
- update the persistent storage navigation entry with the CyVerse URL that includes the resource identifier

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68d1692e40048325a88122cb12cd5783